### PR TITLE
Ignore query vars for registered routes

### DIFF
--- a/lib/Virtual_Page.php
+++ b/lib/Virtual_Page.php
@@ -132,6 +132,32 @@ class Virtual_Page {
 			$regex_pattern      = '^' . $this->slug . '/(?!' . $ignored_permalinks . ')(.*)$';
 		}
 
+		/**
+		 * Have WordPress ignore all URL query variables if the request is explicity for a
+		 * registered React application.
+		 *
+		 * This prevents any conflicts with WordPress' reservered terms and query vars used
+		 * by a registered React application.
+		 *
+		 * i.e.
+		 *    `?p=3` may be intended to be page 3 of some paginated results within React
+		 *     but WordPress thinks we want to go get a post with ID=3.
+		 *
+		 * @link https://codex.wordpress.org/Function_Reference/register_taxonomy#Reserved_Terms
+		 */
+		add_filter(
+			'request',
+			function( $request ) {
+				if ( array_key_exists( $this->key, $request ) ) {
+					$react_app_loader_request = [
+						$this->key => '1'
+					];
+					return $react_app_loader_request;
+				}
+				return $request;
+			}
+		);
+
 		add_rewrite_rule(
 			$regex_pattern,
 			'index.php?' . $this->key . '=1',

--- a/lib/Virtual_Page.php
+++ b/lib/Virtual_Page.php
@@ -150,7 +150,7 @@ class Virtual_Page {
 			function( $request ) {
 				if ( array_key_exists( $this->key, $request ) ) {
 					$react_app_loader_request = [
-						$this->key => '1'
+						$this->key => '1',
 					];
 					return $react_app_loader_request;
 				}


### PR DESCRIPTION
Have WordPress ignore all URL query variables if the request is explicitly for a registered React application. This prevents any conflicts with WordPress' reserved terms and query vars used by a registered React application.

i.e.
`?p=3` may be intended to be page 3 of some paginated results within React but WordPress thinks we want to go get a post with ID=3.